### PR TITLE
Fix profile link for Alain Schlesser

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,5 @@ The following people have helped out in the project and are much appreciated for
 
 * [Jip Moors](https://profiles.wordpress.org/jipmoors)
 * [Sergey Biryukov](https://profiles.wordpress.org/sergeybiryukov)
-* [Alain Schlesser](https://profiles.wordpress.org/alain-schlesser)
+* [Alain Schlesser](https://profiles.wordpress.org/schlessera)
 


### PR DESCRIPTION
Sorry for providing such a silly PR, but please change the profile link to the correct profile 'schlessera', to avoid people pinging me on an account I don't monitor.